### PR TITLE
Corrected git clone command

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Everything you need to quickly build your SaaS, AI product, or any other web app
 
 1. Clone the repository:
     ```
-    git clone [https://github.com/michaelshimeles/nextjs14-starter-template.git](https://github.com/michaelshimeles/nextjs14-starter-template)
+    git clone https://github.com/michaelshimeles/nextjs14-starter-template
     ```
 2. Install the required dependencies:
     ```


### PR DESCRIPTION
The git clone command had the url written a  markdown link instead of just a bare url