### PR TITLE
Fixed pricing to say /yr instead of /mo for yearly plan pricing

### DIFF
--- a/components/homepage/pricing.tsx
+++ b/components/homepage/pricing.tsx
@@ -150,7 +150,7 @@ const PricingCard = ({
                 "text-gray-300": exclusive,
               })}
             >
-              /mo
+              {isYearly ? "/yr" : "/mo"}
             </span>
           </div>
 


### PR DESCRIPTION
Was browsing and saw the yearly plan still said $100 /mo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the pricing display to automatically show monthly or yearly indicators based on the selected billing cycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->