### PR TITLE
docs: update env file reference from .env.example to .env.template

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ bun install
 
 3. Set up environment variables:
 ```bash
-cp .env.example .env.local
+cp .env.template .env.local
 ```
 
 4. Configure your environment variables:


### PR DESCRIPTION
Updates the README.md to reference the correct environment template file name (.env.template instead of .env.example) to match the actual file in the repository. This change improves documentation accuracy and ensures users follow the correct setup process.